### PR TITLE
Fix existing code

### DIFF
--- a/pages/basedatos/regulaciones/index.vue
+++ b/pages/basedatos/regulaciones/index.vue
@@ -310,17 +310,35 @@
                                     header: 'ID',
                                     cell: ({ row }: { row: any }) => `#${row.index + 1}`
                                 },
-                                {
-                                    accessorKey: 'imagenes',
-                                    header: 'Fotos',
-                                    cell: ({ row }: { row: any }) => {
-                                        const imagenes = row.getValue('imagenes')
-                                        return h(ImageModal, {
-                                            images: imagenes || [],
-                                            altText: 'Vista previa de imagen'
-                                        })
-                                    }
-                                },
+                                                                    {
+                                        accessorKey: 'imagenes',
+                                        header: 'Fotos',
+                                        cell: ({ row }: { row: any }) => {
+                                            const imagenes = row.getValue('imagenes') as string[] || []
+                                            
+                                            if (imagenes.length === 0) {
+                                                return h('span', { class: 'text-gray-400 text-sm' }, 'Sin imágenes')
+                                            }
+                                            
+                                            return h('div', { class: 'flex flex-wrap gap-1' }, 
+                                                imagenes.slice(0, 3).map((imagen, index) => 
+                                                    h('img', {
+                                                        src: getImageUrl(imagen),
+                                                        alt: `Imagen ${index + 1}`,
+                                                        class: 'w-10 h-10 rounded object-cover cursor-pointer hover:opacity-80 transition-opacity border border-gray-200',
+                                                        onClick: () => openImageModal(imagen)
+                                                    })
+                                                ).concat(
+                                                    imagenes.length > 3 ? [
+                                                        h('div', { 
+                                                            class: 'w-10 h-10 rounded bg-gray-100 dark:bg-gray-700 flex items-center justify-center text-xs text-gray-600 dark:text-gray-300 cursor-pointer hover:bg-gray-200 dark:hover:bg-gray-600 transition-colors',
+                                                            onClick: () => openImageModal(imagenes[3])
+                                                        }, `+${imagenes.length - 3}`)
+                                                    ] : []
+                                                )
+                                            )
+                                        }
+                                    },
                                 {
                                     accessorKey: 'observaciones',
                                     header: 'Descripciones minimas',


### PR DESCRIPTION
Corrects `ImageModal` usage in regulations table by displaying image thumbnails for multiple images.

---
<a href="https://cursor.com/background-agent?bcId=bc-973cc506-2af9-4ff6-8185-363bf69af3ca">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-973cc506-2af9-4ff6-8185-363bf69af3ca">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

