### PR TITLE
Agregar columna Origen marketing para perfil Jefe Marketing

### DIFF
--- a/components/cargaconsolidada/cotizaciones/CotizacionesView/index.vue
+++ b/components/cargaconsolidada/cotizaciones/CotizacionesView/index.vue
@@ -245,6 +245,7 @@ const { cotizaciones,
     deleteCotizacionFile,
     sendRecordatorioFirmaContrato,
     updateEstadoCotizacionCotizador,
+    updateOrigenMarketing,
     loading: loadingCotizaciones,
     error: errorCotizaciones,
     pagination: paginationCotizaciones,
@@ -2833,6 +2834,22 @@ const handleUpdateEstadoCotizacion = async (idCotizacion: number, estado: string
         showError('Error al actualizar el estado de la cotizaciÃ³n', error)
     }
 }
+
+const handleUpdateOrigenMarketing = async (idCotizacion: number, origen: string | null) => {
+    try {
+        await withSpinner(async () => {
+            const response = await updateOrigenMarketing(idCotizacion, origen)
+            if (response?.success) {
+                showSuccess('Origen actualizado', 'El origen de marketing se guardó correctamente.')
+                await getCotizaciones(Number(id))
+            } else {
+                showError('Error', response?.message || 'No se pudo guardar el origen de marketing')
+            }
+        }, 'Guardando origen marketing...')
+    } catch (error: any) {
+        showError('Error', error?.message || 'No se pudo guardar el origen de marketing')
+    }
+}
 const handleUpdateProveedorEstado = async (idProveedor: number, estado: string, idCotizacion: number) => {
     try {
         await withSpinner(async () => {
@@ -2923,8 +2940,41 @@ const toReadOnlyColumns = (columns: TableColumn<any>[]) => {
         return !READ_ONLY_COLUMN_KEYS.has(key)
     })
 }
+
+const ORIGEN_MARKETING_OPTIONS = [
+    { label: 'Seleccione origen', value: '' },
+    { label: 'Facebook', value: 'Facebook' },
+    { label: 'Instagram', value: 'Instagram' },
+    { label: 'Tiktok', value: 'Tiktok' },
+    { label: 'Landing CC', value: 'Landing CC' },
+    { label: 'Landing CI', value: 'Landing CI' },
+    { label: 'Pagina web CC', value: 'Pagina web CC' },
+    { label: 'Pagina web CI', value: 'Pagina web CI' },
+]
+
+const origenMarketingColumn = (): TableColumn<any> => ({
+    accessorKey: 'origen_marketing',
+    header: 'Origen marketing',
+    cell: ({ row }: { row: any }) => {
+        const current = row.original.origen_marketing ?? ''
+        return h(USelect as any, {
+            items: ORIGEN_MARKETING_OPTIONS,
+            placeholder: 'Seleccione origen',
+            modelValue: current,
+            class: 'min-w-40',
+            'onUpdate:modelValue': (value: any) => {
+                const next = !value ? null : String(value)
+                const prev = row.original.origen_marketing ?? null
+                if (next !== prev) {
+                    handleUpdateOrigenMarketing(row.original.id, next)
+                }
+            }
+        })
+    }
+})
+
 const toMarketingProspectosColumns = (columns: TableColumn<any>[]) => {
-    return columns.map((column: any) => {
+    const mapped = columns.map((column: any) => {
         const key = String(column?.accessorKey ?? column?.id ?? '').toLowerCase()
         if (!READ_ONLY_COLUMN_KEYS.has(key)) return column
         return {
@@ -2944,6 +2994,16 @@ const toMarketingProspectosColumns = (columns: TableColumn<any>[]) => {
             ])
         }
     })
+
+    const result: TableColumn<any>[] = []
+    for (const column of mapped) {
+        result.push(column)
+        const key = String((column as any)?.accessorKey ?? (column as any)?.id ?? '').toLowerCase()
+        if (key === 'estado_cliente' || key === 'tipo_cliente') {
+            result.push(origenMarketingColumn())
+        }
+    }
+    return result
 }
 const getProespectosColumns = () => {
     if (currentRole.value === ROLES.JEFE_MARKETING) return toMarketingProspectosColumns(prospectosCoordinacionColumns.value)

--- a/composables/cargaconsolidada/useCotizacion.ts
+++ b/composables/cargaconsolidada/useCotizacion.ts
@@ -183,6 +183,9 @@ export const useCotizacion = () => {
             throw error
         }
     }
+    const updateOrigenMarketing = async (id: number, origen_marketing: string | null) => {
+        return await CotizacionService.updateOrigenMarketing(id, origen_marketing)
+    }
     const getHeaders = async (id: number) => {
         loadingHeaders.value = true
         try {
@@ -335,6 +338,7 @@ export const useCotizacion = () => {
         createProspecto,
         updateCotizacion,
         updateEstadoCotizacionCotizador,
+        updateOrigenMarketing,
         getHeaders,
         carga,
         loadingHeaders,

--- a/services/cargaconsolidada/cotizacionService.ts
+++ b/services/cargaconsolidada/cotizacionService.ts
@@ -137,6 +137,20 @@ export class CotizacionService extends BaseService {
             throw new Error(error)
         }
     }
+    static async updateOrigenMarketing(id: number, origen_marketing: string | null) {
+        try {
+            return await this.apiCall<{ success: boolean; message?: string; data?: { id: number; origen_marketing: string | null } }>(
+                `${this.baseUrl}/cotizaciones/${id}/origen-marketing`,
+                {
+                    method: 'POST',
+                    body: { origen_marketing }
+                }
+            )
+        } catch (error) {
+            console.error('Error al actualizar origen marketing:', error)
+            throw error
+        }
+    }
     static async getHeaders(id: number): Promise<CotizacionesHeadersResponse> {
         try {
             const response = await this.apiCall<CotizacionesHeadersResponse>(`${this.baseUrl}/cotizaciones/${id}/headers`, {

--- a/types/cargaconsolidada/cotizaciones.ts
+++ b/types/cargaconsolidada/cotizaciones.ts
@@ -14,6 +14,8 @@ export interface Cotizacion {
     estado: string
     estado_cliente: string
     estado_cotizador: string
+    tipo_cliente?: string | null
+    origen_marketing?: string | null
     monto: string
     monto_final: string | null
     volumen: string


### PR DESCRIPTION
## Summary
- Columna **Origen marketing** (select) despues de T. Cliente, solo para rol Jefe Marketing.
- Opciones: Facebook, Instagram, Tiktok, Landing CC/CI, Pagina web CC/CI.
- Guarda via composable/service al endpoint de origen-marketing.

## Test plan
- [ ] Como Jefe Marketing, ver la columna tras T. Cliente en prospectos.
- [ ] Cambiar origen y verificar que se guarda y permanece al recargar.
- [ ] Otros roles no ven la columna.
